### PR TITLE
Use absolute link for gitbook to recognise it

### DIFF
--- a/shared-modules/advanced-team-processes/README.md
+++ b/shared-modules/advanced-team-processes/README.md
@@ -19,4 +19,4 @@ This module aims to build on your project management and team collaboration skil
 
 ## Prerequisites
 
-- [Team Processes Intro](../../courses/Foundation/team-processes-intro/)
+- [Team Processes Intro](/courses/foundation/team-processes-intro/)


### PR DESCRIPTION
If gitbook doesn't recognise the link as internal, it will link to the github source. I think this changes fixes it 👀 