### PR TITLE
Added pre-assignment material from old curriculum

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Courses Overview](courses/README.md)
 
 - [Pre-Course](courses/pre-course/README.md)
+  - [Pre-Assignment](courses/pre-course/pre-assignment/README.md)
   - [Self Study](courses/pre-course/self-study/README.md)
 
 - [Foundation](courses/foundation/README.md)

--- a/courses/pre-course/README.md
+++ b/courses/pre-course/README.md
@@ -4,4 +4,5 @@ The Pre-Course is a collection of tasks that you should complete before joining 
 
 ## Modules
 
+### [Pre-Assigmment](./pre-assignment/README.md)
 ### [Self Study](./self-study/README.md)

--- a/courses/pre-course/pre-assignment/README.md
+++ b/courses/pre-course/pre-assignment/README.md
@@ -1,0 +1,35 @@
+# Waiting to start the test assignment?
+
+Here you can find a short list of resources to try out and get a small head-start for the test assignment.
+
+## HTML and CSS Intro
+
+If you don't know where to start, you can try some of these free online tutorials:
+[freeCodeCamp](https://www.freecodecamp.org/)
+[SCRIMBA](https://scrimba.com/g/ghtml)
+[sololearn](https://sololearn.com/) (mobile-friendly)
+
+
+These are just suggestions - there are lots of other free online courses available online and it all depends on your personal preference.
+
+## JavaScript Intro
+
+A big part of our 7 month program is based on the programming language JavaScript. Try to have a first look at what JavaScript is with some of these free online tutorials:
+
+[freeCodeCamp](https://www.freecodecamp.org/)
+[FrontendMasters](https://frontendmasters.com/courses/web-development-v2/)
+[codecademy](https://www.codecademy.com/learn/introduction-to-javascript)
+
+You can find lots more resources to learn from in the [FrontendMasters "Learn JavaScript" list](https://frontendmasters.com/books/front-end-handbook/2018/learning/javascript.html).
+
+## Frontend Developer Handbook
+
+If you prefer theory and reading up before taking a plunge into the coding world - then we recommend having a look at the below handbook. Reading this text will explain you a lot about what it means to be a web-developer. We really recommend it.
+
+[Front End Developer Handbook](https://frontendmasters.com/books/front-end-handbook/2019/) (yes, the 2019 version is still relevant and no newer versions exist).
+
+## Frontend Developer Roadmap
+If you're curious about what technologies are relevant in the field of Frontend Development - take a look at [this roadmap](https://roadmap.sh/frontend). It's totally fine if you don't recognize over 90% of the words - but return to this map as you keep learning and slowly you might be able to see your own path.
+
+
+Don't worry if everything doesn't immediately make sense, that's what we can help with later. But do make sure that you understand the difference between HTML, CSS and JavaScript and what they are used for: [HTML, CSS, JavaScript Explained](https://youtu.be/gT0Lh1eYk78).


### PR DESCRIPTION
This was available in the old curriculum here https://github.com/HackYourFuture-CPH/curriculum/blob/main/pre-introduction.md

And it was linked to on the website (and maybe other places) for people who are applying.

Moving it into the new pre-course course as a new module.