### PR TITLE
(foundation): fix for broken html-css prep link

### DIFF
--- a/courses/foundation/html-and-css/week1/preparation.md
+++ b/courses/foundation/html-and-css/week1/preparation.md
@@ -12,7 +12,7 @@ If you are new to Figma, watch this [10 min intro for developers](https://youtu.
 
 ### The Code
 
-We have provided some initial code and images for you here: [Code](../order-form-task/) & [Images](../order-form-task/images). Feel free to use these as a starting point.
+We have provided some initial code and images for you here: [Code & Images](https://github.com/HackYourFuture-CPH/program/tree/main/courses/foundation/html-and-css/order-form-task). Feel free to use these as a starting point.
 
 Make sure that your code is:
 


### PR DESCRIPTION
The html-css prep link here:
<img width="1167" height="426" alt="image" src="https://github.com/user-attachments/assets/cd9c0f21-74bd-40fe-a00b-4f2747c52815" />

lead to a 404 page. 

Fixed by adding full external link. 
