### PR TITLE
Update git hyf-assignment instructions

### DIFF
--- a/courses/foundation/git/week1/session-plan.md
+++ b/courses/foundation/git/week1/session-plan.md
@@ -85,7 +85,7 @@ These are some examples of previously created materials by mentors that you can 
 
 ### Exercise 1: Assignments repository
 
-**Objective:** Create a repository on your GitHub following the instructions from [hyf-assignment-template](https://github.com/HackYourFuture-CPH/hyf-assignment-template). Then you will add the session exercises from the previous week, to the `html-css/week1` folder, by first checking out to a new branch called `html-and-css`. Create a PR  to your own repo introducing those changes to `main`. Finally, have the person on your right review this PR before you agree to merge it to `main`.
+**Objective:** Create a repository on your GitHub following the instructions from [hyf-assignment-template](https://github.com/HackYourFuture-CPH/hyf-assignment-template). Then you will add the session exercises from the previous week, to the `html-css/week1` folder, by first checking out to a new branch called `html-and-css`. Create a PR to your own repo introducing those changes to `main`. Finally, have the person on your right review this PR before you agree to merge it to `main`.
 
 - Use descriptive `commit` messages
 - Make a commit for each folder/exercise you add (makes it easier to track changes/updates)


### PR DESCRIPTION
Related to this change https://github.com/HackYourFuture-CPH/hyf-assignment-template/pull/37

Remove the instruction related to "use template" and make it more generic, so it simply links to the instructions on the hyf-assignment-repo.