### PR TITLE
Update contributor guide

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -26,7 +26,7 @@ Permissions are managed through GitHub teams, their roles on this repo, and bran
 
 - _HYF Staff_ members have the admin role (to do things like changing repo settings, inviting new contributors).
 - Members of the _Curriculum Crew_ team on GitHub have the write role (to do things like cloning, pushing branches, approving PRs - any volunteer is welcome here!).
-- One approval by anyone in _Curriculum Crew_ or _HYF Staff_ are required on a PR before merging is allowed.
+- One approval by anyone in _Curriculum Crew_ or _HYF Staff_ is required on a PR before merging is allowed.
 - Merging to `main` can be performed by any _HYF Staff_ member.
 
 ## Setting up and using your local environment


### PR DESCRIPTION
After discussion with the staff team, i'm modifying the contributor guidelines to be more explicit about when and how mentors should help contribute to the program content.

Maybe the biggest shift with these changes is moving most ongoing conversations and feedback regarding the program into #mentorroom instead of #curriculum-crew (which soon will be rescoped to be only about changes left in the 2.0 launch project).

More tidying up of channels/github projects to come after this!