### PR TITLE
Foundation - Git - Add information about PRs and forks to session plan

### DIFF
--- a/courses/foundation/git/week1/session-plan.md
+++ b/courses/foundation/git/week1/session-plan.md
@@ -91,7 +91,7 @@ These are some examples of previously created materials by mentors that you can 
     - GitLens - Git supercharged
     - GitHub Pull Requests
 
-### Exercise 1:
+### Exercise 1
 
 **Objective:** The goal is to set up your assignment repository fork and create your first PR (Pull Request).
 


### PR DESCRIPTION
**Main changes:**

**1. Updated session plan with two new sections:**
- Pull Requests (reminder to explain creating, reviewing, merging PRs). Useful for the exercises.
- Forks

**2. Breaks down `exercise #1` into numbered steps**
- The instructions for **exercise 1** were written in a conversational format. This PR changes it to follow the format of the rest of the exercises with a numbered list. To make it easier to follow.
- Added a link to the `README.md` section of the `hyf-assignment-template` repo that explains how to create a PR to an own fork

Minor changes (unrelated):
- removed note about central/individual repo approaches (I assume this is outdated content)
- added small note about showing `git add` with all files vs. specific files. Trainees had issues with adding specific files during assignments due to not knowing they needed to type the entire path of the files.



