### PR TITLE
Linting: Ensure the validateLinks.js script is built

### DIFF
--- a/lint
+++ b/lint
@@ -6,7 +6,8 @@ validate-links() {
     echo "validate-links: RUN"
     # If the support/dist directory does not exist, build it
     if [ ! -d "support/dist" ]; then
-      ./node_modules/.bin/tsc -p support/tsconfig.json
+      echo "Building project before running linting scripts"
+      npm run build
     fi
 
     if npm exec -- node support/dist/validateLinks.js ; then


### PR DESCRIPTION
Linting currently depends on multiple tasks:

- one of them is `validate-links()`: A JS script that needs to be built in the `support/dist` directory before being able to run `./lint` locally

This means, if `./lint` is run before building the program, it fails due to a missing script, and contributors upon a clean install, would have to build the program at least once (npm run build) to be able to run `./lint` 

Otherwise, they'd get this error: 
```Error: Cannot find module '.../hyf/program/support/dist/validateLinks.js'```

**This PR fixes that:**

This change ensures the `support` project is built with the local version of `tsc` before running the linter. Only if it doesn't exist already.