### PR TITLE
Foundation/Intro to Agile : add "lost at sea" exercise to session outline

### DIFF
--- a/courses/foundation/intro-to-agile/week1/session-plan.md
+++ b/courses/foundation/intro-to-agile/week1/session-plan.md
@@ -156,7 +156,6 @@ You can use some of these questions (or statements) to debrief the exercise and 
 {% endhint %}
 
 {% hint style="info" %}
-**FOR FACILITATORS ONLY**
 
 ---
 


### PR DESCRIPTION
After a discussion with the staff, it was suggested to add this exercise to the "intro to agile session" 
The goal is to have an interactive team exercise to put the trainees in a situation where they can relate to the problems that the agile methodology and principles address (in a way). 
What's New
New Exercise: Lost at Sea (under 45 minutes)

A survival scenario where teams must rank 15 items by importance
Individual ranking phase (10 min) → Team discussion (15 min) → Debrief (10 min)
Includes a surprise time pressure element to simulate real project dynamics
Expert solution revealed via interactive web tool: https://siderdk.github.io/lostAtSea/

Learning Outcomes
The exercise demonstrates key Agile principles experientially:

Responding to change - Sudden time constraint forces adaptation
Team collaboration - Requires unanimous decision-making under pressure
Communication breakdown - Shows how stress impacts team dynamics
Decision-making trade-offs - Speed vs. consensus vs. quality

Implementation Details
Facilitator guide outlined in hint blocks ( hopefully the trainees won't see spoilers)
Clear facilitation script with timing and discussion questions
Links to external scoring tool for answer reveal
Connects back to Agile principles throughout the session